### PR TITLE
Update column name in mrt_order_daily_report

### DIFF
--- a/models/mart/mrt_order_daily_report.sql
+++ b/models/mart/mrt_order_daily_report.sql
@@ -1,4 +1,4 @@
-SELECT DATE_TRUNC(order_created_at, DAY) AS report_date,
+SELECT DATE_TRUNC(order_created_at, DAY) AS reporting_date,
     mapping.account_manager,
     mapping.state,
     COUNT(DISTINCT order_id) AS total_orders,


### PR DESCRIPTION
In this pull request we are renaming `report_date` column in mrt_daily_order_report (new name is `reporting_date`).